### PR TITLE
Fix for when 2 reviewers are provided

### DIFF
--- a/app/services/slack/action/add_code_review.rb
+++ b/app/services/slack/action/add_code_review.rb
@@ -20,8 +20,10 @@ module Slack
         given_reviewers = pick_reviewers_by_tags(given_reviewers_tags)
         reviewers = given_reviewers
 
-        reviewers += pick_reviewers_in_project(reviewers, requester)
-        reviewers += pick_external_reviewers(reviewers, requester)
+        unless reviewers.count == 2
+          reviewers += pick_reviewers_in_project(reviewers, requester)
+          reviewers += pick_external_reviewers(reviewers, requester)
+        end
 
         create_code_review(url, reviewers, given_reviewers, requester, channel_id)
       rescue ActiveRecord::RecordNotFound => e

--- a/app/services/slack/action/add_code_review.rb
+++ b/app/services/slack/action/add_code_review.rb
@@ -20,7 +20,7 @@ module Slack
         given_reviewers = pick_reviewers_by_tags(given_reviewers_tags)
         reviewers = given_reviewers
 
-        unless reviewers.count == 2
+        unless reviewers.count == REQUIRED_NUMBER_OF_REVIEWERS
           reviewers += pick_reviewers_in_project(reviewers, requester)
           reviewers += pick_external_reviewers(reviewers, requester)
         end


### PR DESCRIPTION
**Acceptance Criteria**
- The slack app does return a standard code review message

**Notes**
- To test this behaviour: `/cr add code-review https://github.com/boost/boost/pull/1 @katherine @yar`